### PR TITLE
Fxing an nsca config

### DIFF
--- a/nsca.go
+++ b/nsca.go
@@ -28,7 +28,7 @@ func sendNscaMessage(state *uint8, service *string, message *string) error {
 	}
 
 	cmd := exec.Command(config.NSCA.OsCommand, "-H", config.NSCA.Server, "-c", config.NSCA.ConfigFile)
-	cmd.Stdin = strings.NewReader(fmt.Sprintf("%d\t%s\t%s", *state, *service, *message))
+	cmd.Stdin = strings.NewReader(fmt.Sprintf("%s\t%d\t%s\t%s", config.NSCA.ClientHost, *state, *service, *message))
 	err := cmd.Run()
 
 	if *verbose {


### PR DESCRIPTION
I forgot a field in the send_nsca command that causes the application to send PROCESS_HOST_CHECK_RESULT instead of PROCESS_SERVICE_CHECK_RESULT.
